### PR TITLE
correctif : ajout de l'entrée patch / correctif (#39)

### DIFF
--- a/mots/correctif-nom.md
+++ b/mots/correctif-nom.md
@@ -1,0 +1,26 @@
+---
+anglais: patch
+français: correctif
+classe: n. m.
+chemin: correctif-nom
+---
+## note
+
+`Patch` est un anglicisme. `Rustine` est informel.
+
+## exemples
+
+🇬 | 🇫🇷
+---|---
+A security patch was released to fix the critical vulnerability.|Un correctif de sécurité a été publié pour corriger la vulnérabilité critique.
+Administrators are advised to apply patches promptly.|Les administrateurs sont invités à appliquer les correctifs rapidement.
+
+## justification
+
+- [correctif - Office québécois de la langue française](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/8354994/correctif)
+
+## voir aussi
+
+- [bogue](bogue-nom.html)
+- [faille](faille-nom.html)
+- [mise à jour](mise-à-jour-nom.html)


### PR DESCRIPTION
Ajout de l'entrée `correctif` (n. m.) pour le terme anglais `patch`.

## Changements

- `mots/correctif-nom.md` : nouvelle entrée

## Contenu

- Exemples bilingues d'usage en contexte de cybersécurité
- Note distinguant `correctif`, `patch` et `rustine`
- Justification : Office québécois de la langue française
- Liens `voir aussi` : bogue, faille, mise à jour

Ferme #39